### PR TITLE
Fix: HighScore에 보여지는 상위 점수 개수 오류 수정

### DIFF
--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -550,6 +550,7 @@ public final class DrawManager {
 			drawCenteredRegularString(screen, scoreString, screen.getHeight()
 					/ 4 + fontRegularMetrics.getHeight() * (i + 1) * 2);
 			i++;
+			if(i==5) break;
 		}
 	}
 


### PR DESCRIPTION
JIRA ISSUE KEY : IN-61

HighScore에 보여지는 상위 점수 개수를 5개로 제한하여 수정하였습니다 !